### PR TITLE
Ajustes no layout responsivo e prop onEnterKey

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,2 @@
 <link href="https://fonts.googleapis.com/css2?family=Arvo:wght@700&family=Merriweather:wght@400;700&family=Work+Sans:wght@400;700&family=Nunito+Sans:wght@300;400;700&display=swap" rel="stylesheet">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />

--- a/components/Field/Field.stories.js
+++ b/components/Field/Field.stories.js
@@ -15,7 +15,7 @@ export const Primary = () => {
   return (
     <ThemeProvider theme={theme}>
       <div style={{margin: 20}}>
-        <Field placeholder="Digite alguma coisa" enterKey={() => setText('click enter key')} value={state} onChange={setState} validation={false} validationMessage="Teste"/>
+        <Field placeholder="Digite alguma coisa" onEnterKey={() => setText('click enter key')} value={state} onChange={setState} validation={false} validationMessage="Teste"/>
         <pre>{text}</pre>
       </div>
     </ThemeProvider>

--- a/components/Field/index.js
+++ b/components/Field/index.js
@@ -243,7 +243,7 @@ Field.propTypes = {
    */
   mask: PropTypes.string,
   /**
-   * Permite manipular ação de clique na tecla Enter/Return (recebe como parâmetro callback o id do Field)
+   * Função executada quando ocorrer o clique na tecla "Enter"
    */
   onEnterKey: PropTypes.func,
 };

--- a/components/Field/index.js
+++ b/components/Field/index.js
@@ -1,6 +1,6 @@
 import {get} from 'lodash';
 import PropTypes from 'prop-types';
-import React, {useEffect} from 'react';
+import React from 'react';
 import InputMask from 'react-input-mask';
 import {withTheme} from 'styled-components';
 
@@ -32,17 +32,8 @@ const Field = props => {
     id,
     name,
     mask,
-    enterKey
+    onEnterKey
   } = props;
-
-  // Trigger to Handle enter keydown for forms
-  const handleKeyPress = event => {
-    if (event.keyCode === 13) enterKey(id);
-  };
-  useEffect(() => {
-    enterKey && window.addEventListener('keydown', handleKeyPress);
-    return () => enterKey && window.removeEventListener('keydown', handleKeyPress);
-  });
 
   const styledLabelDefaultProps = {
     fontSize: get(styledLabel, 'fontSize', '14px'),
@@ -107,6 +98,10 @@ const Field = props => {
     return <FieldMessage {...styledMessageDefaultProps}>{validationMessage}</FieldMessage>;
   };
 
+  const handleKeyPress = ({key}) => {
+    if (key === 'Enter') onEnterKey();
+  };
+
   return (    
     <Block {...styledFieldDefaultProps} fullWidth>
       {renderLabel()}
@@ -122,6 +117,7 @@ const Field = props => {
           mask={mask}
           placeholder={placeholder}
           validation={validation}
+          onKeyPress={handleKeyPress}
         >
           <Input {...styledRootDefaultProps} />
         </InputMask>
@@ -249,7 +245,7 @@ Field.propTypes = {
   /**
    * Permite manipular ação de clique na tecla Enter/Return (recebe como parâmetro callback o id do Field)
    */
-  enterKey: PropTypes.func,
+  onEnterKey: PropTypes.func,
 };
 
 export default withTheme(Field);

--- a/components/Field/styled.js
+++ b/components/Field/styled.js
@@ -52,7 +52,6 @@ const handleFocusedColor = props => {
 
 export const Input = styled.input`
   width: calc(100% - 16px);
-  height: calc(100% - 2px);
   padding-left: 8px;
   padding-right: 8px;
   font-size: ${handleFontSize};


### PR DESCRIPTION
Antes:
![IMG_2728](https://user-images.githubusercontent.com/24513129/116882780-36d4f880-abfb-11eb-8ed3-7a0092026d49.PNG)

Depois:
![IMG_2729](https://user-images.githubusercontent.com/24513129/116882790-3a687f80-abfb-11eb-8903-1861ef4d1f99.PNG)

Para testar o clique, ao clicar em enter é exibido um texto na tela. O stories é o Field (primeiro na lista esquerda)