### PR TITLE
Altera props default no Article/Share

### DIFF
--- a/components/Article/Share/index.js
+++ b/components/Article/Share/index.js
@@ -14,9 +14,9 @@ const Share = ({facebookPath, fbappid, twitterPath, whatsappPath}) => {
 };
 
 Share.defaultProps = {
-  facebookPath: 'assets/facebook-product1.svg',
-  twitterPath: 'assets/twitter-product1.svg',
-  whatsappPath: 'assets/whatsapp-product1.svg'
+  facebookPath: 'assets/facebook.svg',
+  twitterPath: 'assets/twitter.svg',
+  whatsappPath: 'assets/whatsapp.svg'
 };
 
 Share.propTypes = {


### PR DESCRIPTION
### Quais são as novas props?
Agora o padrão é o nome da rede social, por exemplo:
`facebookPath: "assets/facebook.svg"`