### PR TITLE
Adiciona função getColor ao styled-system

### DIFF
--- a/styled-system/color.js
+++ b/styled-system/color.js
@@ -1,0 +1,9 @@
+import {get} from 'lodash';
+
+export const getColor = ({
+  theme = {},
+  $color = '',
+}) => {
+  const value = get(theme.colors, $color, '');
+  return value;
+};

--- a/styled-system/index.js
+++ b/styled-system/index.js
@@ -1,11 +1,5 @@
-import {border} from './border';
-import {dimensions} from './dimensions';
-import {margin} from './margin';
-import {padding} from './padding';
-
-export {
-  border,
-  dimensions,
-  margin,
-  padding
-};
+export {border} from './border';
+export {dimensions} from './dimensions';
+export {margin} from './margin';
+export {padding} from './padding';
+export {getColor} from './color';


### PR DESCRIPTION
### Como utilizar?
Basta importar a função no arquivo onde está o styled-components. Ela irá buscar o valor string com o nome do token nos tokens disponíveis em theme.

Import:
``import {getColor} from 'prensa/styled-system'``

Exemplo com styled:
``
const Component = styled.div`
background-color: ${getColor}
`
``

No contexto onde será utilizado:
``
<Component $color='primary1' />
``