### PR TITLE
Novo componente SocialShare para web

### DIFF
--- a/components/Article/Article.js
+++ b/components/Article/Article.js
@@ -57,7 +57,7 @@ const Article = (props) => {
             </S.ContainerFeatured>
             <S.MaxWidth maxWidth={headWidth}>
               <S.Content>
-                <Byline {...byline} />
+                <Byline amp={amp} {...byline} />
               </S.Content>
             </S.MaxWidth>
             {adTopImage && React.cloneElement(adTopImage)}

--- a/components/Article/Byline/Byline.js
+++ b/components/Article/Byline/Byline.js
@@ -5,6 +5,7 @@ import Share from '../Share';
 import * as S from './Byline.styled';
 
 const Byline = ({
+  amp,
   author,
   customContent,
   datetime,
@@ -24,7 +25,7 @@ const Byline = ({
             Atualizado há {datetime.time_modified}
           </S.TimeEntry>
         </S.DateLine>
-        <Share {...share} />
+        <Share amp={amp} {...share} />
       </S.Content>
     </S.Container>
   );
@@ -52,6 +53,7 @@ Byline.defaultProps = {
 };
 
 Byline.propTypes = {
+  amp: PropTypes.bool,
   author: PropTypes.object,
   customContent: PropTypes.string,
   datetime: PropTypes.object,

--- a/components/Article/Share/AmpShare.js
+++ b/components/Article/Share/AmpShare.js
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import * as S from './styled';
+
+const Share = props => {
+  const {fbappid, size, facebookPath, facebookProps, twitterPath, twitterProps, whatsappPath, whatsappProps, ...otherProps} = props;
+  return (
+    <S.Container
+      facebookPath={fbappid ? facebookPath : null}
+      twitterPath={twitterPath}
+      whatsappPath={whatsappPath}
+      $size={size}
+      {...otherProps}
+    >
+      {fbappid && <amp-social-share type='facebook' width={size} height={size} data-param-app_id={fbappid} {...facebookProps} />}
+      {twitterPath && <amp-social-share type='twitter' width={size} height={size} {...twitterProps} />}
+      {whatsappPath && <amp-social-share type='whatsapp' width={size} height={size} {...whatsappProps} />}
+    </S.Container>
+  );
+};
+
+Share.defaultProps = {
+  align: 'row',
+  facebookPath: 'assets/facebook.svg',
+  size: '24',
+  twitterPath: 'assets/twitter.svg',
+  whatsappPath: 'assets/whatsapp.svg'
+};
+
+Share.propTypes = {
+  fbappid: PropTypes.string,
+  size: PropTypes.string,
+  itemProps: PropTypes.object,
+  facebookPath: PropTypes.string,
+  facebookProps: PropTypes.object,
+  twitterPath: PropTypes.string,
+  twitterProps: PropTypes.object,
+  whatsappPath: PropTypes.string,
+  whatsappProps: PropTypes.object
+};
+
+export default Share;

--- a/components/Article/Share/IcFacebook.js
+++ b/components/Article/Share/IcFacebook.js
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {IconContainer} from './styled';
+import Icon from '../../Icon';
 
 const IcFaceboook = ({color, height, width}) => {
   return (
-    <IconContainer xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" $color={color} $height={height} $width={width}>
+    <Icon xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" $color={color} $height={height} $width={width}>
       <path d="M22.23,4.15H19.16c-3.45,0-5.69,2.29-5.69,5.83v2.69H10.38a.49.49,0,0,0-.48.48v3.9a.49.49,0,0,0,.48.49h3.09v9.83a.48.48,0,0,0,.49.48h4a.47.47,0,0,0,.48-.48V17.54h3.62a.49.49,0,0,0,.48-.49v-3.9a.49.49,0,0,0-.14-.34.48.48,0,0,0-.34-.14H18.47V10.39c0-1.1.26-1.65,1.69-1.65h2.07a.49.49,0,0,0,.49-.49V4.63A.49.49,0,0,0,22.23,4.15Z"/>
-    </IconContainer>
+    </Icon>
   );
 };
 

--- a/components/Article/Share/IcTwitter.js
+++ b/components/Article/Share/IcTwitter.js
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {IconContainer} from './styled';
+import Icon from '../../Icon';
 
 const IcTwitter = ({color, height, width}) => {
   return (
-    <IconContainer xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" $color={color} $height={height} $width={width}>
+    <Icon xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" $color={color} $height={height} $width={width}>
       <path d="M30,7.33a11.92,11.92,0,0,1-3.31.9A5.65,5.65,0,0,0,29.2,5.06a11.4,11.4,0,0,1-3.63,1.39,5.74,5.74,0,0,0-9.92,3.92,6.19,6.19,0,0,0,.13,1.31A16.23,16.23,0,0,1,4,5.68a5.82,5.82,0,0,0-.78,2.9,5.75,5.75,0,0,0,2.54,4.77,5.73,5.73,0,0,1-2.59-.71v.06a5.77,5.77,0,0,0,4.6,5.64,5.68,5.68,0,0,1-1.51.19,4.88,4.88,0,0,1-1.08-.1,5.78,5.78,0,0,0,5.36,4,11.5,11.5,0,0,1-7.11,2.45A10.54,10.54,0,0,1,2,24.79a16.13,16.13,0,0,0,8.8,2.57c10.55,0,16.32-8.74,16.32-16.31,0-.26,0-.5,0-.75A11.3,11.3,0,0,0,30,7.33Z"/>
-    </IconContainer>
+    </Icon>
   );
 };
 

--- a/components/Article/Share/IcWhatsapp.js
+++ b/components/Article/Share/IcWhatsapp.js
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {IconContainer} from './styled';
+import Icon from '../../Icon';
 
 const IcWhatsapp = ({color, height, width}) => {
   return (
-    <IconContainer xmlns="http://www.w3.org/2000/svg" viewBox='0 0 32 32' $color={color} $height={height} $width={width}>
+    <Icon xmlns="http://www.w3.org/2000/svg" viewBox='0 0 32 32' $color={color} $height={height} $width={width}>
       <path d="M15.43,4.24A11.69,11.69,0,0,0,4.32,15.94a11.52,11.52,0,0,0,1.27,5.27l-1.24,6a.45.45,0,0,0,.55.53l5.9-1.39a11.57,11.57,0,0,0,5,1.21,11.68,11.68,0,1,0-.39-23.34Zm7,18.13A9.17,9.17,0,0,1,11.93,24.1l-.82-.41-3.62.86.76-3.7-.4-.79A9.15,9.15,0,0,1,22.47,9.44a9.05,9.05,0,0,1,2.68,6.46A9.16,9.16,0,0,1,22.47,22.37Z"/>
       <path d="M21.67,18.44l-2.26-.65a.85.85,0,0,0-.84.22l-.55.56a.82.82,0,0,1-.9.19,11.88,11.88,0,0,1-3.89-3.44.82.82,0,0,1,.06-.91l.48-.62a.86.86,0,0,0,.11-.86l-1-2.15a.85.85,0,0,0-1.32-.31,3.83,3.83,0,0,0-1.47,2.25c-.16,1.58.52,3.58,3.09,6,3,2.78,5.35,3.14,6.89,2.77a3.87,3.87,0,0,0,2-1.77A.84.84,0,0,0,21.67,18.44Z"/>
-    </IconContainer>
+    </Icon>
   );
 };
 

--- a/components/Article/Share/Share.js
+++ b/components/Article/Share/Share.js
@@ -1,0 +1,80 @@
+import {get} from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FacebookShareButton as Facebook, TwitterShareButton as Twitter, WhatsappShareButton as Whatsapp} from 'react-share';
+import styled, {css} from 'styled-components';
+
+import {margin} from '../../../styled-system';
+import Block from '../../Block';
+import FacebookIcon from './IcFacebook';
+import TwitterIcon from './IcTwitter';
+import WhatsappIcon from './IcWhatsapp';
+
+
+const getShareButtonSize = ({size}) => {
+  return `${size}px`;
+};
+
+const getHoverStyle = () => {
+  return css`
+    &:hover {
+      opacity: 0.8;
+    }
+  `;
+};
+
+const FacebookShareButton = styled(Facebook)`
+  width: ${getShareButtonSize};
+  height: ${getShareButtonSize};
+  ${getHoverStyle};
+  ${margin};
+`;
+const TwitterShareButton = styled(Twitter)`
+  width: ${getShareButtonSize};
+  height: ${getShareButtonSize};
+  ${getHoverStyle};
+  ${margin};
+`;
+const WhatsappShareButton = styled(Whatsapp)`
+  width: ${getShareButtonSize};
+  height: ${getShareButtonSize};
+  ${getHoverStyle};
+`;
+
+const itemDefaultProps = {
+  size: 24,
+  mr: 4
+};
+
+const Share = props => {
+  const {itemProps, facebookProps, twitterProps, whatsappProps, ...otherProps} = props;
+  const url = get(location, 'href');
+  return (
+    <Block align='row' width='100%' alignx='right' {...otherProps}>
+      <FacebookShareButton url={url} {...itemDefaultProps} {...itemProps} {...facebookProps}>
+        <FacebookIcon/>
+      </FacebookShareButton>
+      <TwitterShareButton url={url} {...itemDefaultProps} {...itemProps} {...twitterProps}>
+        <TwitterIcon/>
+      </TwitterShareButton>
+      <WhatsappShareButton url={url} {...itemDefaultProps} {...itemProps} {...whatsappProps}>
+        <WhatsappIcon/>
+      </WhatsappShareButton>
+    </Block>
+  );
+};
+
+Share.defaultProps = {
+  align: 'row',
+  size: '24'
+};
+
+Share.propTypes = {
+  size: PropTypes.string,
+  itemProps: PropTypes.object,
+  facebookProps: PropTypes.object,
+  twitterProps: PropTypes.object,
+  whatsappProps: PropTypes.object
+};
+
+export default Share;

--- a/components/Article/Share/Share.js
+++ b/components/Article/Share/Share.js
@@ -4,7 +4,7 @@ import React from 'react';
 import {FacebookShareButton as Facebook, TwitterShareButton as Twitter, WhatsappShareButton as Whatsapp} from 'react-share';
 import styled, {css} from 'styled-components';
 
-import {margin} from '../../../styled-system';
+import {margin} from '../../../styled-system/margin';
 import Block from '../../Block';
 import FacebookIcon from './IcFacebook';
 import TwitterIcon from './IcTwitter';

--- a/components/Article/Share/index.js
+++ b/components/Article/Share/index.js
@@ -1,43 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import * as S from './styled';
+import AmpShare from './AmpShare';
+import Share from './Share';
 
-const Share = props => {
-  const {fbappid, size, facebookPath, facebookProps, twitterPath, twitterProps, whatsappPath, whatsappProps, ...otherProps} = props;
-  return (
-    <S.Container
-      facebookPath={fbappid ? facebookPath : null}
-      twitterPath={twitterPath}
-      whatsappPath={whatsappPath}
-      $size={size}
-      {...otherProps}
-    >
-      {fbappid && <amp-social-share type='facebook' width={size} height={size} data-param-app_id={fbappid} {...facebookProps} />}
-      {twitterPath && <amp-social-share type='twitter' width={size} height={size} {...twitterProps} />}
-      {whatsappPath && <amp-social-share type='whatsapp' width={size} height={size} {...whatsappProps} />}
-    </S.Container>
-  );
+const SocialShare = props => {
+  const {amp} = props;
+  if (amp) return <AmpShare {...props} />;
+  return <Share {...props} />;
 };
 
-Share.defaultProps = {
-  align: 'row',
-  facebookPath: 'assets/facebook.svg',
-  size: '24',
-  twitterPath: 'assets/twitter.svg',
-  whatsappPath: 'assets/whatsapp.svg'
+SocialShare.propTypes = {
+  amp: PropTypes.bool
 };
 
-Share.propTypes = {
-  fbappid: PropTypes.string,
-  size: PropTypes.string,
-  itemProps: PropTypes.object,
-  facebookPath: PropTypes.string,
-  facebookProps: PropTypes.object,
-  twitterPath: PropTypes.string,
-  twitterProps: PropTypes.object,
-  whatsappPath: PropTypes.string,
-  whatsappProps: PropTypes.object
-};
-
-export default Share;
+export default SocialShare;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^17.0.1",
     "react-input-mask": "^3.0.0-alpha.2",
     "sass": "^1.26.10",
-    "styled-components": "^5.x"
+    "styled-components": "^5.x",
+    "react-share": "4.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.10.4",
@@ -83,5 +84,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
+  },
+  "dependencies": {
+    "react-share": "^4.4.0"
   }
 }


### PR DESCRIPTION
O componente pode receber as mesmas props que são recebidas na sua versão AMP, excetuando as props facebookPath, twitterPath e whatsappPath pois o método de obtenção dos ícones é diferente.

Para o AMP a obtenção dos ícones se dá pela execução de um estilo CSS `background-image: url(...);` onde as props path recebem a url para o estilo anterior.

A versão WEB trabalha com a biblioteca react-share utilizando os ShareButtons da library e os ícones internos do prensa.
https://www.npmjs.com/package/react-share

### ATENÇÃO!
A biblioteca react-share é peer-dependency no Prensa. É necessário instalar ela no respectivo projeto frontend.
<pre>
npm install react-share@4.4.0
# ou
yarn add react-share@4.4.0
</pre>