### PR TITLE
Permite nova propriedade site_data no PageBlock

### DIFF
--- a/src/components/PageBlock/index.tsx
+++ b/src/components/PageBlock/index.tsx
@@ -77,9 +77,10 @@ const PageBlock = ({
           column_padding: 0,
           layouts: slot100_layout,
           preview,
-          spaceB: slot4_slotList,
+          site_data,
           slot: [],
           slot_parser,
+          spaceB: slot4_slotList,
         }}
         slot100={{
           amp,
@@ -92,10 +93,11 @@ const PageBlock = ({
           layouts: slot100_layout,
           min_height: slot100_block.min_height,
           preview,
+          site_data,
           slot: slot1.list1,
           slot_parser,
           spaceA: slotsHaveSecionTitle ? slot1_title : null,
-          spaceB: slot1_slotList
+          spaceB: slot1_slotList,
         }}
       />
     )
@@ -115,9 +117,10 @@ const PageBlock = ({
           column_padding: 0,
           layouts: slot70_layout,
           preview,
-          spaceB: slot4_slotList,
+          site_data,
           slot: [],
           slot_parser,
+          spaceB: slot4_slotList,
         }}
         slot70={{
           amp,
@@ -130,6 +133,7 @@ const PageBlock = ({
           min_height: slot70_block.min_height,
           layouts: slot70_layout,
           preview,
+          site_data,
           slot: slot1.list1,
           slot_parser,
           spaceA: slotsHaveSecionTitle ? slot1_title : null,
@@ -146,6 +150,7 @@ const PageBlock = ({
           layouts: slot30_layout,
           min_height: slot30_block.min_height,
           preview,
+          site_data,
           slot: slot2.list1,
           slot_parser,
           spaceA: slotsHaveSecionTitle ? slot2_title : null,
@@ -169,9 +174,10 @@ const PageBlock = ({
           column_padding: 0,
           layouts: slotLeft_layout,
           preview,
-          spaceB: slot4_slotList,
+          site_data,
           slot: [],
           slot_parser,
+          spaceB: slot4_slotList,
         }}
         slotLeft={{
           amp,
@@ -184,6 +190,7 @@ const PageBlock = ({
           layouts: slotLeft_layout,
           min_height: slotLeft_block.min_height,
           preview,
+          site_data,
           slot: slot1.list1,
           slot_parser,
           spaceA: slotsHaveSecionTitle ? slot1_title : null,
@@ -200,6 +207,7 @@ const PageBlock = ({
           layouts: slotRight_layout,
           min_height: slotRight_block.min_height,
           preview,
+          site_data,
           slot: slot2.list1,
           slot_parser,
           spaceA: slotsHaveSecionTitle ? slot2_title : null,
@@ -230,9 +238,10 @@ const PageBlock = ({
           column_padding: 0,
           layouts: slotLeft_layout,
           preview,
-          spaceB: slot4_slotList,
+          site_data,
           slot: [],
           slot_parser,
+          spaceB: slot4_slotList,
         }}
         slotLeft={{
           amp,
@@ -246,6 +255,7 @@ const PageBlock = ({
           layouts: slotLeft_layout,
           min_height: slotLeft_block.min_height,
           preview,
+          site_data,
           slot: slot1.list1,
           slot_parser,
           spaceA: slotsHaveSecionTitle ? slot1_title : null,
@@ -263,6 +273,7 @@ const PageBlock = ({
           layouts: slotCenter_layout,
           min_height: slotCenter_block.min_height,
           preview,
+          site_data,
           slot: slot2.list1,
           slot_parser,
           spaceA: slotsHaveSecionTitle ? slot2_title : null,
@@ -280,6 +291,7 @@ const PageBlock = ({
           layouts: slotRight_layout,
           min_height: slotRight_block.min_height,
           preview,
+          site_data,
           slot: slot3.list1,
           slot_parser,
           spaceA: slotsHaveSecionTitle ? slot3_title : null,
@@ -299,9 +311,10 @@ const PageBlock = ({
         column_padding: 0,
         layouts: slowWrap_layout,
         preview,
-        spaceB: slot4_slotList,
+        site_data,
         slot: [],
         slot_parser,
+        spaceB: slot4_slotList,
       }}
       slotItems={{
         amp,
@@ -314,6 +327,7 @@ const PageBlock = ({
         layouts: slowWrap_layout,
         min_height: slowWrap_block.min_height,
         preview,
+        site_data,
         slot: slot1.list1,
         slot_parser,
         spaceA: slotsHaveSecionTitle ? slot1_title : null,

--- a/src/components/PageBlock/index.tsx
+++ b/src/components/PageBlock/index.tsx
@@ -24,6 +24,7 @@ const PageBlock = ({
   fallback_image_url,
   preview,
   section_title_component,
+  site_data,
   slot_parser,
   slot1,
   slot2,
@@ -59,10 +60,10 @@ const PageBlock = ({
     customComponent: section_title_component
   })
   // define slot spaceB
-  const slot1_slotList = selectComponentFromSlotList(slot_parser, slot1?.list2)
-  const slot2_slotList = selectComponentFromSlotList(slot_parser, slot2?.list2)
-  const slot3_slotList = selectComponentFromSlotList(slot_parser, slot3?.list2)
-  const slot4_slotList = selectComponentFromSlotList(slot_parser, slot4?.list)
+  const slot1_slotList = selectComponentFromSlotList(slot_parser, slot1?.list2, site_data)
+  const slot2_slotList = selectComponentFromSlotList(slot_parser, slot2?.list2, site_data)
+  const slot3_slotList = selectComponentFromSlotList(slot_parser, slot3?.list2, site_data)
+  const slot4_slotList = selectComponentFromSlotList(slot_parser, slot4?.list, site_data)
 
   if (type === 'template100') {
     const slot100_block = selectTemplateFromTheme({ block: 'slot100', slot: slot1, templates })

--- a/src/components/PageBlock/types.ts
+++ b/src/components/PageBlock/types.ts
@@ -30,6 +30,7 @@ export type PageBlockProps = {
   type: string;
   preview: PageBlockPreview;
   section_title_component?: any;
+  site_data: any;
   slot_parser: any;
   slot1: SlotBlockProps;
   slot2: SlotBlockProps;

--- a/src/components/PageBlock/utils.tsx
+++ b/src/components/PageBlock/utils.tsx
@@ -30,12 +30,13 @@ export const selectMinHeightFromSlot = (minHeight): string => {
  */
 export const selectComponentFromSlotList = (
   parseSlot: any,
-  slotList: any
+  slotList: any,
+  siteData: any
 ) => {
   if (!parseSlot)
     return <></>
   return (
-    <>{map(slotList, (item, key) => parseSlot(item, key))}</>
+    <>{map(slotList, (item, key) => parseSlot(item, key, siteData))}</>
   )
 }
 

--- a/src/components/RenderSlot/index.tsx
+++ b/src/components/RenderSlot/index.tsx
@@ -24,6 +24,7 @@ const RenderSlot = ({
   layout,
   layouts,
   preview,
+  site_data,
   slot,
   slot_parser,
   theme
@@ -36,7 +37,7 @@ const RenderSlot = ({
   const RenderSpace = ({ item }) => {
     if (item && item['input-template']) {
       if (slot_parser) {
-        const space = selectComponentFromSlotList(slot_parser, [item])
+        const space = selectComponentFromSlotList(slot_parser, [item], site_data)
         return renderSpaceSlot(space)
       }
     }

--- a/src/components/RenderSlot/types.ts
+++ b/src/components/RenderSlot/types.ts
@@ -17,6 +17,7 @@ export type RenderSlotProps = {
   layouts: Array<string>;
   min_height?: [string, string];
   preview: PageBlockPreview;
+  site_data: any;
   slot: Array<any>;
   slot_parser: any;
   /**

--- a/src/components/SectionTitle/index.tsx
+++ b/src/components/SectionTitle/index.tsx
@@ -24,10 +24,10 @@ const SectionTitle = ({
   theme
 }: SectionTitleProps) => {
 
-  const area_layout = layout?.area || {}
-  const icon_layout = layout?.icon || {}
-  const link_layout = layout?.link || {}
-  const text_layout = layout?.text || {}
+  const area_layout: any = layout?.area || {}
+  const icon_layout: any = layout?.icon || {}
+  const link_layout: any = layout?.link || {}
+  const text_layout: any = layout?.text || {}
 
   function get_icon_from_theme() {
     //Todo: Create log patter for theme findings errors


### PR DESCRIPTION
### O que esse PR implementa?
Nova propriedade `site_data` no componente PageBlock o que permitirá a capilarização dos dados passados para a propriedade aos componentes dentro dos slots. Será o resultado de `content.pageindex`

Em um novo PR serão adicionados a esse fluxo de dados as props `fallback_image_url` e `site_template` que hoje circulam em fluxos de dados individuais