### PR TITLE
Altera espaçamento do px no Body do Article

### DIFF
--- a/src/components/Article/TextBody/TextBody.styled.js
+++ b/src/components/Article/TextBody/TextBody.styled.js
@@ -23,8 +23,8 @@ export const Body = ({
       px: '0px',
       width: '100%'
     }}
-    px={3}
-    width='calc(100% - 48px)'>
+    px={2}
+    width='calc(100% - 32px)'>
     {children}
   </Block>
 }


### PR DESCRIPTION
O espaçamento não estava coerente com a maioria dos layouts, que usa 16px no left e no right.