### PR TITLE
Aplica uso do get na função border do styled system

### DIFF
--- a/styled-system/border.js
+++ b/styled-system/border.js
@@ -25,7 +25,7 @@ export function border(props) {
 
   const colors = get(theme, 'colors', {})
   const radius_options = get(theme, 'radius')
-  const selectedColor = colors[borderColor]
+  const selectedColor = get(colors, borderColor)
 
   let object = []
 


### PR DESCRIPTION
Isso corrige um erro ao utilizar novos formatos de tokens de cor como `primary.main`