### PR TITLE
Ajustes de estilo no componente AccordionEditorial

### DIFF
--- a/components/AccordionEditorial/index.js
+++ b/components/AccordionEditorial/index.js
@@ -30,7 +30,7 @@ const AccordionEditorial = ({
   removeBorders
 }) => {
   return (
-    <Block px={px} py={py}>
+    <Block px={px} py={py} width='100%'>
       {title &&
         <Typography
           {...titleDefaultProps}

--- a/components/AccordionEditorial/index.js
+++ b/components/AccordionEditorial/index.js
@@ -16,19 +16,51 @@ const titleDefaultProps = {
   mb: 3,
 }
 
-const AccordionEditorial = ({ amp, color, items, title, titleProps, groupItemProps, groupSubItemProps, groupTitleProps, px, py, removeBorders }) => {
+const AccordionEditorial = ({
+  amp,
+  color,
+  items,
+  title,
+  titleProps,
+  groupItemProps,
+  groupSubItemProps,
+  groupTitleProps,
+  px,
+  py,
+  removeBorders
+}) => {
   return (
     <Block px={px} py={py}>
       {title &&
-        <Typography {...titleDefaultProps} {...titleProps}>
+        <Typography
+          {...titleDefaultProps}
+          {...titleProps}
+        >
           {title}
         </Typography>
       }
       {items && 
         map(items, (item, key) => amp ? 
-          <AmpGroup color={color} content={item} groupTitleProps={groupTitleProps} groupSubItemProps={groupSubItemProps} groupItemProps={groupItemProps} key={key} removeBorders={removeBorders} />
+          <AmpGroup
+            color={color}
+            content={item}
+            groupTitleProps={groupTitleProps}
+            groupSubItemProps={groupSubItemProps}
+            groupItemProps={groupItemProps}
+            key={key}
+            removeBorders={removeBorders}
+          />
           :
-          <Group color={color} content={item} groupTitleProps={groupTitleProps} groupSubItemProps={groupSubItemProps} groupItemProps={groupItemProps} key={key} removeBorders={removeBorders} />)
+          <Group
+            color={color}
+            content={item}
+            groupTitleProps={groupTitleProps}
+            groupSubItemProps={groupSubItemProps}
+            groupItemProps={groupItemProps}
+            key={key}
+            removeBorders={removeBorders}
+          />
+        )
       }
     </Block>
   )

--- a/components/AccordionEditorial/styled.js
+++ b/components/AccordionEditorial/styled.js
@@ -37,9 +37,6 @@ const GroupSection = styled.section`
   .hidden {
     display: none;
   }
-  @media (min-width: ${props => props.theme.queries.md}) {
-    width: 340px;
-  }
 `
 
 const getGroupBorder = ({ removeBorders }) => {

--- a/components/SideMenu/index.tsx
+++ b/components/SideMenu/index.tsx
@@ -17,6 +17,7 @@ const SideMenu = ({ amp, ...otherProps }: SideMenuProps) => {
 
 SideMenu.defaultProps = {
   backgroundColor: 'white',
+  height: '100vh',
   layout: 'nodisplay',
   menuAnchor: 'left',
   width: 'max-content'

--- a/stories/AccordionEditorial/data.json
+++ b/stories/AccordionEditorial/data.json
@@ -1,0 +1,35 @@
+[
+  {
+    "contentId": "2.639",
+    "input-template": "p.siteengine.Page",
+    "path": "http://localhost:8080/noticias",
+    "link": "",
+    "name": "Notícias",
+    "subitems": [
+      {
+        "contentId": "2.628",
+        "input-template": "p.siteengine.Page",
+        "path": "http://localhost:8080/brasil",
+        "link": "",
+        "name": "Brasil",
+        "subitems": []
+      },
+      {
+        "contentId": "1.184",
+        "input-template": "br.com.atex.plugins.menu-tag.it",
+        "name": "Subitem Externo",
+        "path": "https://www.google.com.br",
+        "subitems": [],
+        "window": "true"
+      }
+    ]
+  },
+  {
+    "contentId": "1.183",
+    "input-template": "br.com.atex.plugins.menu-tag.it",
+    "name": "Item com link externo",
+    "path": "http://www.odiariodemogi.net.br/educacao",
+    "subitems": [],
+    "window": "true"
+  }
+]

--- a/stories/AccordionEditorial/index.stories.tsx
+++ b/stories/AccordionEditorial/index.stories.tsx
@@ -1,0 +1,47 @@
+import { AccordionEditorial } from 'prensa'
+import React from 'react'
+import { theme } from 'storybook/theme'
+import { ThemeProvider } from 'styled-components'
+
+import data from './data.json'
+
+export default {
+  title: 'AccordionEditorial',
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <Story />
+      </ThemeProvider>
+    )
+  ]
+}
+
+export const AccordionWeb = () => {
+  return (
+    <AccordionEditorial 
+      amp={false}
+      items={data}
+      title='teste'
+      titleProps={{ color: 'product1' }}
+      groupTitleProps={{ color: 'product2', pl: '16px' }}
+      groupSubItemProps={{ color: 'neutral2', fontSize: '20px' }}
+      menuItemProps={{ pl: '32px' }}
+      color='primary1'
+    />
+  )
+}
+
+export const AccordionAmp = () => {
+  return (
+    <AccordionEditorial 
+      amp={true}
+      items={data}
+      title='teste'
+      titleProps={{ color: 'product1' }}
+      groupTitleProps={{ color: 'product2', pl: '16px' }}
+      groupSubItemProps={{ color: 'neutral2', fontSize: '20px' }}
+      menuItemProps={{ pl: '32px' }}
+      color='primary1'
+    />
+  )
+}


### PR DESCRIPTION
- Remove regra responsiva (a responsabilidade deve ser do componente pai, o AccordionEditorial cresce sempre 100% do espaço disponível)
- Adiciona regra width 100% no container do componente
- Cria stories com exemplos do componente em AMP e Web