### PR TITLE
Ajustar width do SideMenu quando mobile

### DIFF
--- a/components/SideMenu/index.tsx
+++ b/components/SideMenu/index.tsx
@@ -20,7 +20,7 @@ SideMenu.defaultProps = {
   height: '100vh',
   layout: 'nodisplay',
   menuAnchor: 'left',
-  width: ['300px', '360px']
+  width: ['calc(100% - 48px)', '360px']
 }
 
 export default SideMenu


### PR DESCRIPTION
O tamanho do SideMenu estava em 300px ocasionando a quebra. Estamos aplicando padding de 24px nesse caso, então devemos aplicar 0 100% - 48px para poder evitar a quebra.