### PR TITLE
Ajustar posicionamento do título da Coluna no AuthorProfile

### DIFF
--- a/components/AuthorProfile/index.tsx
+++ b/components/AuthorProfile/index.tsx
@@ -69,11 +69,8 @@ const AuthorProfile = ({
         <S.TitleWrapper>
           {title &&
             <Block
-              alignx='center'
-              lg={{
-                align: 'row',
-                alignx: 'left'
-              }}
+              alignx='left'
+              align='row'
               mb={1}
               width='100%'>
               <Link path={href}>


### PR DESCRIPTION
Essa branch ajusta o posicionamento do título da Coluna dentro do AuthorProfile. O posicionamento estava em center, o esperado era left.