### PR TITLE
Revisar alinhamento lateral dos elementos no topo da matéria

### DIFF
--- a/components/Article/Article.styled.js
+++ b/components/Article/Article.styled.js
@@ -25,8 +25,8 @@ Container.propTypes = {
 
 export const Content = ({ children }) => 
   <Block
-    px={3}
-    width='calc(100% - 48px)'
+    px={2}
+    width='calc(100% - 32px)'
     lg={{
       px: '0px',
       width: '100%'


### PR DESCRIPTION
O espaçamento do content do topo da matéria não estava alinhado com o texto da matéria. 