### PR TITLE
Adiciona propridade profileImage no teaser

### DIFF
--- a/components/Teaser/index.tsx
+++ b/components/Teaser/index.tsx
@@ -104,11 +104,11 @@ const Teaser = (props: TeaserProps) => {
   // profile enabled and options
   const profile_data = get(item, 'parentBio', false)
   const profile_data_visible = get(profile_data, 'enabled', false)
+  const profile_image_enabled = get(layout, 'profile_image.enabled', false)
   const profile_layout = get(layout, 'profile_bio', {})
+  const profile_layout_enabled = get(layout, 'profile_bio.enabled', false)
   const profile_layout_height = get(profile_layout, 'height', ['40px', '40px'])
   const profile_layout_width = get(profile_layout, 'width', ['40px', '40px'])
-  const profile_layout_enabled = get(layout, 'profile_bio.enabled', false)
-  const profile_image_enabled = get(layout, 'profile_image.enabled', false)
   const isProfileEnabled = profile_data_visible && profile_layout_enabled
 
   //related
@@ -159,16 +159,18 @@ const Teaser = (props: TeaserProps) => {
     if (!image_enabled) {
       return null
     }
-    let profile_image_parsed = item.img
+
     if (profile_image_enabled) {
-      profile_image_parsed = {
-        byl: '',
-        cap: profile_content?.name,
-        cid: profile_content?.image?.contentId,
-        sub: ''
+      if (item) {
+        item['img'] = {
+          byl: '',
+          cap: profile_content?.name,
+          cid: profile_content?.image?.contentId,
+          sub: ''
+        }
       }
     }
-    const item_parsed = { ...item, img: profile_image_parsed }
+
     return (
       <S.WrapContent
         wrap_align={image_align}
@@ -187,7 +189,7 @@ const Teaser = (props: TeaserProps) => {
           editable={editable}
           fallback_image_url={fallback_image_url}
           image_circle={layout?.image_circle}
-          item={item_parsed}
+          item={item}
           item_path={item_path}
           layout={layout}
           opacityMask={opacity_mask}

--- a/components/Teaser/index.tsx
+++ b/components/Teaser/index.tsx
@@ -108,6 +108,7 @@ const Teaser = (props: TeaserProps) => {
   const profile_layout_height = get(profile_layout, 'height', ['40px', '40px'])
   const profile_layout_width = get(profile_layout, 'width', ['40px', '40px'])
   const profile_layout_enabled = get(layout, 'profile_bio.enabled', false)
+  const profile_image_enabled = get(layout, 'profile_image.enabled', false)
   const isProfileEnabled = profile_data_visible && profile_layout_enabled
 
   //related
@@ -158,6 +159,16 @@ const Teaser = (props: TeaserProps) => {
     if (!image_enabled) {
       return null
     }
+    let profile_image_parsed = item.img
+    if (profile_image_enabled) {
+      profile_image_parsed = {
+        byl: '',
+        cap: profile_content?.name,
+        cid: profile_content?.image?.contentId,
+        sub: ''
+      }
+    }
+    const item_parsed = { ...item, img: profile_image_parsed }
     return (
       <S.WrapContent
         wrap_align={image_align}
@@ -176,7 +187,7 @@ const Teaser = (props: TeaserProps) => {
           editable={editable}
           fallback_image_url={fallback_image_url}
           image_circle={layout?.image_circle}
-          item={item}
+          item={item_parsed}
           item_path={item_path}
           layout={layout}
           opacityMask={opacity_mask}

--- a/components/Teaser/types.ts
+++ b/components/Teaser/types.ts
@@ -108,6 +108,9 @@ export type LayoutProps = {
     height?: SpacingType,
     width?: SpacingType
   };
+  profile_image?: {
+    enabled: boolean,
+  };
   related?: Related;
   section?: Object;
   subject?: SubjectLayout;

--- a/styles/demo/hed/editable/index.tsx
+++ b/styles/demo/hed/editable/index.tsx
@@ -85,7 +85,7 @@ const save_action = async () => {
 }
 // editable actions
 export const preview_editable = {
-  enabled: true,
+  enabled: false,
   render: preview_render,
   save_action: save_action
 }

--- a/styles/demo/hed/teasers/teaser_image_circle.ts
+++ b/styles/demo/hed/teasers/teaser_image_circle.ts
@@ -24,6 +24,9 @@ export const TEASER_IMAGE_CIRCLE = CreateTeaser({
     wrap_width: ['80px', '120px']
   },
   image_circle: true,
+  profile_image: {
+    enabled: true
+  },
   title: {
     enabled: true,
     ...parseFonts(


### PR DESCRIPTION
CONTEXTO

Permitir utilizar a imagem da editoria ao invés da imagem da matéria

CASO DE USO

Teaser de colunista deve exibir a imagem do profile ao invés da imagem da matéria.

![Screen Shot 2022-01-30 at 19 07 32](https://user-images.githubusercontent.com/1500027/151719876-683f0a12-93b2-4f3b-943d-d92c7e5e6856.png)
