### PR TITLE
Altera chamada do otherProps na desestruturação (Componentes de Share)

### DIFF
--- a/components/Article/Share/FacebookShareButton/index.tsx
+++ b/components/Article/Share/FacebookShareButton/index.tsx
@@ -17,7 +17,7 @@ const FacebookShareButton = (props: FacebookShareButtonProps) => {
     size
   } = props
 
-  const { mt, mb, mr, ml, ...otherProps } = facebookProps
+  const { mt, mb, mr, ml, otherProps } = facebookProps
 
   const displayParam = '&display=popup'
   const fbappidParam = `?app_id=${fbappid}`

--- a/components/Article/Share/FacebookShareButton/types.ts
+++ b/components/Article/Share/FacebookShareButton/types.ts
@@ -5,6 +5,7 @@ export type FacebookProps = {
   mr?: number | string;
   mb?: number | string;
   ml?: number | string;
+  otherProps?: any;
 }
 
 export type FacebookShareButtonProps = {

--- a/components/Article/Share/TwitterShareButton/index.tsx
+++ b/components/Article/Share/TwitterShareButton/index.tsx
@@ -16,7 +16,7 @@ const TwitterShareButton = (props: TwitterShareButtonProps) => {
     twitterProps = {}
   } = props
 
-  const { mt, mb, mr, ml, ...otherProps } = twitterProps
+  const { mt, mb, mr, ml, otherProps } = twitterProps
 
   const pageUrlParam = `url=${pageUrl}`
   const shareUrl = `https://twitter.com/intent/tweet?${pageUrlParam}`

--- a/components/Article/Share/TwitterShareButton/types.ts
+++ b/components/Article/Share/TwitterShareButton/types.ts
@@ -5,6 +5,7 @@ export type TwitterProps = {
   mr?: number | string;
   mb?: number | string;
   ml?: number | string;
+  otherProps?: any;
 }
 
 export type TwitterShareButtonProps = {

--- a/components/Article/Share/WhatsAppShareButton/index.tsx
+++ b/components/Article/Share/WhatsAppShareButton/index.tsx
@@ -16,7 +16,7 @@ const WhatsAppShareButton = (props: WhatsAppShareButtonProps) => {
     whatsappProps = {},
   } = props
 
-  const { mt, mb, mr, ml, ...otherProps } = whatsappProps
+  const { mt, mb, mr, ml, otherProps } = whatsappProps
 
   const textParam = `?text=${pageUrl}`
   const shareUrl = `https://api.whatsapp.com/send${textParam}`

--- a/components/Article/Share/WhatsAppShareButton/types.ts
+++ b/components/Article/Share/WhatsAppShareButton/types.ts
@@ -5,6 +5,7 @@ export type WhatsAppProps = {
   mr?: number | string;
   mb?: number | string;
   ml?: number | string;
+  otherProps?: any;
 }
 
 export type WhatsAppShareButtonProps = {


### PR DESCRIPTION
**O que esse PR implementa?**

Notamos uma inconsistência em todos os shares que temos no projeto, segue a imagem a baixo:

![image](https://user-images.githubusercontent.com/39891863/160492413-19f77595-4128-4d89-8330-a26e31b2d718.png)

O spread que acontece no otherProps não vai ter efeito uma vez que otherProps não foi definido em nenhum momento, essa alteração leva o otherProps até os types e, de fato, permite sua utilização.