### PR TITLE
Feat/article image click to open

### DIFF
--- a/components/Article/Image/index.js
+++ b/components/Article/Image/index.js
@@ -1,4 +1,5 @@
 import { get } from 'lodash'
+import { Link } from 'prensa'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -60,20 +61,15 @@ const ArticleImage = ({
         />
       )
     }
-    return (
-      <img
-        alt={captionValue}
-        src={value}
-      />
-    )
+    return <img alt={captionValue} src={value} />
   }
 
   const RenderClickArea = ({ children }) => {
     if (clickToOpen) {
       return (
-        <a href={value} target="_blank" rel="noreferrer">
+        <Link href={value} target='_blank' rel='noreferrer' width='100%'>
           {children}
-        </a>
+        </Link>
       )
     }
     return <>{children}</>
@@ -123,7 +119,7 @@ ArticleImage.defaultProps = {
     fontSize: ['14px', '14px'],
     lineHeight: ['130%', '130%'],
     show: true,
-    value: 'Legenda da Imagem',
+    value: 'Legenda da Imagem'
   },
   clickToOpen: false,
   height: '640px',

--- a/components/Article/Image/index.js
+++ b/components/Article/Image/index.js
@@ -14,6 +14,7 @@ const ArticleImage = ({
   amp,
   ampElementProps,
   caption,
+  clickToOpen,
   featured,
   height,
   image,
@@ -67,6 +68,17 @@ const ArticleImage = ({
     )
   }
 
+  const RenderClickArea = ({ children }) => {
+    if (clickToOpen) {
+      return (
+        <a href={value} target="_blank" rel="noreferrer">
+          {children}
+        </a>
+      )
+    }
+    return <>{children}</>
+  }
+
   const RenderMedia = () => {
     switch (type) {
       case 'video':
@@ -78,7 +90,9 @@ const ArticleImage = ({
 
   return (
     <Container featured={featured} mb={mb} value={value}>
-      <RenderMedia />
+      <RenderClickArea>
+        <RenderMedia />
+      </RenderClickArea>
       {showCaption && captionValue && (
         <S.SubtitleBox px={px} py={py} widthBox={widthBox}>
           <S.Subtitle
@@ -111,6 +125,7 @@ ArticleImage.defaultProps = {
     show: true,
     value: 'Legenda da Imagem',
   },
+  clickToOpen: false,
   height: '640px',
   mb: [2, 2],
   px: [3, 4],
@@ -123,6 +138,7 @@ ArticleImage.defaultProps = {
 ArticleImage.propTypes = {
   amp: PropTypes.bool,
   caption: PropTypes.object,
+  clickToOpen: PropTypes.bool,
   featured: PropTypes.bool,
   height: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   image: PropTypes.bool,

--- a/components/Article/Image/index.js
+++ b/components/Article/Image/index.js
@@ -16,6 +16,7 @@ const ArticleImage = ({
   ampElementProps,
   caption,
   clickToOpen,
+  customClick,
   featured,
   height,
   image,
@@ -66,8 +67,14 @@ const ArticleImage = ({
 
   const RenderClickArea = ({ children }) => {
     if (clickToOpen) {
+      const clickToOpenHref = customClick ? customClick : value
       return (
-        <Link href={value} target='_blank' rel='noreferrer' width='100%'>
+        <Link
+          href={clickToOpenHref}
+          target='_blank'
+          rel='noreferrer'
+          width='100%'
+        >
           {children}
         </Link>
       )
@@ -122,6 +129,7 @@ ArticleImage.defaultProps = {
     value: 'Legenda da Imagem'
   },
   clickToOpen: false,
+  customClick: '',
   height: '640px',
   mb: [2, 2],
   px: [3, 4],
@@ -135,6 +143,7 @@ ArticleImage.propTypes = {
   amp: PropTypes.bool,
   caption: PropTypes.object,
   clickToOpen: PropTypes.bool,
+  customClick: PropTypes.string,
   featured: PropTypes.bool,
   height: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
   image: PropTypes.bool,


### PR DESCRIPTION
Exemplo: https://www.acritica.com/geral/premio-acumulado-de-loteria-americana-esta-em-us-246-milh-es-1.248438