### PR TITLE
feat(button): New rules in Button regarding text label spacing and rendering with Typography

### DIFF
--- a/packages/xprog-prensa/primitives/Button/component.tsx
+++ b/packages/xprog-prensa/primitives/Button/component.tsx
@@ -8,6 +8,7 @@ export const Button: React.FC<ButtonProps> = ({
   children,
   color,
   css,
+  labelSpacing,
   iconLeft,
   iconRight,
   variant,
@@ -16,7 +17,10 @@ export const Button: React.FC<ButtonProps> = ({
   ...otherProps
 }) => {
 
+  // variants css defintion
+  let css_label_spacing = { px: `$${labelSpacing}` }
   let css_variant = {}
+
   switch (variant) {
     case 'filled':
       css_variant = {
@@ -46,16 +50,44 @@ export const Button: React.FC<ButtonProps> = ({
       }
   }
 
+  let button_css = { ...css_variant }
+  let label_css = { ...css_label_spacing }
+
+  if (css && css.button) {
+    button_css = { ...button_css, ...css.button }
+  }
+  if (css && css.label) {
+    label_css = { ...label_css, ...css.label }
+  }
+
+  const renderChildren = () => {
+    if (typeof children === 'string') {
+      return (
+        <Typography
+          as='span'
+          variant={textVariant}
+          css={label_css}
+        >
+          {children}
+        </Typography>
+      )
+    } else {
+      return (
+        <>
+          {children}
+        </>
+      )
+    }
+  }
+
   return (
     <StyledButton
       className='pds-Button-root'
-      css={{ ...css_variant, ...css }}
+      css={button_css}
       {...otherProps}
     >
       {iconLeft && iconLeft}
-      <Typography as='span' variant={textVariant}>
-        {children}
-      </Typography>
+      {renderChildren()}
       {iconRight && iconRight}
     </StyledButton>
   )
@@ -63,6 +95,7 @@ export const Button: React.FC<ButtonProps> = ({
 
 Button.defaultProps = {
   color: 'neutral2',
+  labelSpacing: '3',
   size: 'md',
   textVariant: 'default-texts-sm',
   variant: 'filled',

--- a/packages/xprog-prensa/primitives/Button/props.ts
+++ b/packages/xprog-prensa/primitives/Button/props.ts
@@ -1,10 +1,12 @@
 import { ReactNode } from 'react'
 
-import { PrensaColorTokens, PrensaTypeSystemTokens } from '../../types'
+import { PrensaColorTokens, PrensaTypeSystemTokens, PrensaSpaceTokens } from '../../types'
 import { StyledButtonTypes } from './styles'
 
 export type ButtonProps = StyledButtonTypes['defaultProps'] & {
   color?: PrensaColorTokens;
+  css?: { button: {}; label: {}; };
+  labelSpacing?: PrensaSpaceTokens;
   iconLeft?: ReactNode;
   iconRight?: ReactNode;
   textColor?: PrensaColorTokens;

--- a/packages/xprog-prensa/primitives/Button/props.ts
+++ b/packages/xprog-prensa/primitives/Button/props.ts
@@ -5,7 +5,7 @@ import { StyledButtonTypes } from './styles'
 
 export type ButtonProps = StyledButtonTypes['defaultProps'] & {
   color?: PrensaColorTokens;
-  css?: { button: {}; label: {}; };
+  css?: { button?: {}; label?: {}; };
   labelSpacing?: PrensaSpaceTokens;
   iconLeft?: ReactNode;
   iconRight?: ReactNode;

--- a/packages/xprog-prensa/primitives/Button/styles.ts
+++ b/packages/xprog-prensa/primitives/Button/styles.ts
@@ -5,7 +5,8 @@ export const StyledButton = PrensaEngine.styled('button', {
   borderStyle: 'solid',
   borderWidth: '1px',
   cursor: 'pointer',
-  px: '$4',
+  py: '$0',
+  px: '$3',
   width: 'max-content',
   '&:disabled': {
     backgroundColor: '$neutral10',

--- a/packages/xprog-prensa/storybook/Button.stories.tsx
+++ b/packages/xprog-prensa/storybook/Button.stories.tsx
@@ -178,3 +178,23 @@ export const Colored = () => {
     </PrensaThemeProvider>
   )
 }
+
+export const Customizations = () => {
+  return (
+    <PrensaThemeProvider>
+      <Block css={{ align: ['row', 'evenly', 'middle'], height: '100vh' }}>
+        <Button
+          size='md'
+          variant='outlined'
+          iconLeft={<IconComponent/>}
+          color='errorMain'
+          labelSpacing='10'
+          textVariant='brand-newsTitle-sm'
+          css={{ button: { borderWidth: '3px' } }}
+        >
+          Brown Fox
+        </Button>
+      </Block>
+    </PrensaThemeProvider>
+  )
+}


### PR DESCRIPTION
What this PR implements?
- New renderChildren function checking if children is string. If is string, render Typography + children value. If it is not string   renders children only allowing use of customized components encapsulating value.
```
<Button>
   <MyComponent>
      {value}
   </MyComponent>
</Button>
```
- New rules for CSS prop defining styles flux. CSS prop expects button or label
```
<Button css={{ button: {}, label: {} }} />
```