### PR TITLE
Aplica prop ariaLabel no Link e atualiza share do Article

### DIFF
--- a/packages/prensa/components/Article/Share/FacebookShareButton/index.tsx
+++ b/packages/prensa/components/Article/Share/FacebookShareButton/index.tsx
@@ -52,7 +52,9 @@ const FacebookShareButton = (props: FacebookShareButtonProps) => {
         ml={ml}
       >
         <Link
+          ariaLabel="Compartilhar no Facebook"
           height={size}
+          hoverOpacity={0.8}
           path={shareUrl}
           target='_blank'
         >

--- a/packages/prensa/components/Article/Share/LinkedinShareButton/index.tsx
+++ b/packages/prensa/components/Article/Share/LinkedinShareButton/index.tsx
@@ -47,7 +47,9 @@ const LinkedinShareButton = (props: LinkedinShareButtonProps) => {
         ml={ml}
       >
         <Link
+          ariaLabel="Compartilhar no Linkedin"
           height={size}
+          hoverOpacity={0.8}
           path={shareUrl}
           target='_blank'
         >

--- a/packages/prensa/components/Article/Share/TelegramShareButton/index.tsx
+++ b/packages/prensa/components/Article/Share/TelegramShareButton/index.tsx
@@ -49,7 +49,9 @@ const TelegramShareButton = (props: TelegramShareButtonProps) => {
         ml={ml}
       >
         <Link
+          ariaLabel='Compartilhar no Telegram'
           height={size}
+          hoverOpacity={0.8}
           path={shareUrl}
           target='_blank'
         >

--- a/packages/prensa/components/Article/Share/TwitterShareButton/index.tsx
+++ b/packages/prensa/components/Article/Share/TwitterShareButton/index.tsx
@@ -47,7 +47,9 @@ const TwitterShareButton = (props: TwitterShareButtonProps) => {
         ml={ml}
       >
         <Link
+          ariaLabel='Compartilhar no Twitter'
           height={size}
+          hoverOpacity={0.8}
           path={shareUrl}
           target='_blank'
         >

--- a/packages/prensa/components/Article/Share/WhatsAppShareButton/index.tsx
+++ b/packages/prensa/components/Article/Share/WhatsAppShareButton/index.tsx
@@ -48,7 +48,9 @@ const WhatsAppShareButton = (props: WhatsAppShareButtonProps) => {
         ml={ml}
       >
         <Link
+          ariaLabel='Compartilhar no WhatsApp'
           height={size}
+          hoverOpacity={0.8}
           path={shareUrl}
           target='_blank'
         >

--- a/packages/prensa/components/Link/index.tsx
+++ b/packages/prensa/components/Link/index.tsx
@@ -8,6 +8,7 @@ import { LinkProps } from './types'
  * @description Link component is an abstraction for <a/>
  */
 const Link = ({
+  ariaLabel,
   children,
   color,
   display,
@@ -30,6 +31,7 @@ const Link = ({
 
   return (
     <StyledLink
+      aria-label={ariaLabel}
       href={path || href}
       $color={color}
       $display={display}

--- a/packages/prensa/components/Link/types.ts
+++ b/packages/prensa/components/Link/types.ts
@@ -12,6 +12,7 @@ export interface LinkProps extends HTMLProps<HTMLAnchorElement> {
   align?: AlignStyledFunctionParam0['align'];
   alignx?: AlignStyledFunctionParam0['alignx'];
   aligny?: AlignStyledFunctionParam0['aligny'];
+  ariaLabel?: string;
   b?: string;
   borderColor?: ColorTokens;
   borderStyle?: string;

--- a/packages/prensa/components/Teaser/RenderImage.tsx
+++ b/packages/prensa/components/Teaser/RenderImage.tsx
@@ -7,6 +7,7 @@ import { parseImagePath } from '../Image/parser'
 import { ImagePreviewLink } from '../Image/preview'
 import { parseContentId } from '../Util/parseContentId'
 import { RenderOpacityMask } from './RenderOpacityMask'
+import Link from '../Link'
 import * as S from './styled'
 
 type RenderImageProps = {
@@ -165,9 +166,13 @@ const RenderImage = ({
       )
     }
     return (
-      <S.AreaLink href={item_path}>
+      <Link 
+        ariaLabel='Imagem da Notícia'
+        hoverOpacity={0.8}
+        href={item_path}
+        width='100%'>
         <RenderImageElement />
-      </S.AreaLink>
+      </Link>
     )
   }
   if (editable && editable.enabled) {


### PR DESCRIPTION
Foi habilitada a prop ariaLabel no componente Link para cumprir os requerimentos de acessibilidade. Foram atualizados os ícones das redes sociais com seus respectivos ariaLabel.